### PR TITLE
ci: change english to default build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
           npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
       - name: Build
         run: |
-          npm run-script build:prod
+          npm run-script build:prod:ghpages
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.2.3
         with:

--- a/angular.json
+++ b/angular.json
@@ -85,7 +85,8 @@
               "namedChunks": true
             },
             "fr": {
-              "localize": ["fr"]
+              "localize": ["fr"],
+              "deleteOutputPath": false
             }
           },
           "defaultConfiguration": "production"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "start-fr": "ng serve --configuration=fr",
         "build": "ng build --configuration development --localize",
         "build:prod": "ng build --configuration production --localize",
+        "build:prod:ghpages": "ng build --configuration production && ng build --configuration production,fr",
         "watch": "ng build --watch --configuration development --localize",
         "test": "ng test",
         "test:once": "ng test --watch=false --browsers ChromeHeadlessCI",


### PR DESCRIPTION
still publishes french at /fr/ but deploys english to the root.

Currently going to https://readalong-studio.mothertongues.org/ produces a 404. I think we should have English be the default (we can't write redirect rules since we're just using GitHub Pages).