### PR TITLE
Update to SoundSwallower 0.6.0

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -32,7 +32,7 @@
             "assets": [
               "src/assets",
               {
-                "glob": "soundswallower.wasm",
+                "glob": "soundswallower.web.wasm",
                 "input": "./node_modules/soundswallower",
                 "output": "."
               },
@@ -123,7 +123,7 @@
             "assets": [
               "src/favicon.ico",
               {
-                "glob": "soundswallower.wasm",
+                "glob": "soundswallower.web.wasm",
                 "input": "./node_modules/soundswallower",
                 "output": "."
               },

--- a/angular.json
+++ b/angular.json
@@ -32,11 +32,6 @@
             "assets": [
               "src/assets",
               {
-                "glob": "soundswallower.web.wasm",
-                "input": "./node_modules/soundswallower",
-                "output": "."
-              },
-              {
                 "glob": "**/*",
                 "ignore": ["fr-fr/*"],
                 "input": "./node_modules/soundswallower/model",
@@ -122,11 +117,6 @@
             "inlineStyleLanguage": "sass",
             "assets": [
               "src/favicon.ico",
-              {
-                "glob": "soundswallower.web.wasm",
-                "input": "./node_modules/soundswallower",
-                "output": "."
-              },
               {
                 "glob": "**/*",
                 "ignore": ["fr-fr/*"],

--- a/custom-webpack.config.js
+++ b/custom-webpack.config.js
@@ -1,16 +1,11 @@
 module.exports = {
-  // Eliminate emscripten's node junk when using webpack
-  resolve: {
-    fallback: {
-      crypto: false,
-      fs: false,
-      path: false,
+  // Stop webpack from munging import.meta.url (this should be the default in
+  // Angular but unfortunately it isn't)
+  module: {
+    parser: {
+      javascript: {
+        importMeta: false,
+      },
     },
-  },
-  // ARGH! More node junk! WTF!
-  node: {
-    global: false,
-    __filename: false,
-    __dirname: false,
   },
 };

--- a/custom-webpack.config.js
+++ b/custom-webpack.config.js
@@ -1,10 +1,8 @@
 module.exports = {
-  // Stop webpack from munging import.meta.url (this should be the default in
-  // Angular but unfortunately it isn't)
   module: {
     parser: {
       javascript: {
-        importMeta: false,
+        url: true,
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,12 @@
                 "@angular/platform-browser": "^15.1.1",
                 "@angular/platform-browser-dynamic": "^15.1.1",
                 "@angular/router": "^15.1.1",
+                "@types/emscripten": "^1.39.6",
                 "angular-shepherd": "^14.0.0",
                 "bootstrap": "^5.2.3",
                 "ngx-toastr": "^15.0.0",
                 "rxjs": "~7.5.0",
-                "soundswallower": "^0.5.0",
+                "soundswallower": "^0.6.0",
                 "standardized-audio-context": "^25.3.36",
                 "tslib": "^2.3.0",
                 "zone.js": "~0.11.4"
@@ -12160,9 +12161,9 @@
             }
         },
         "node_modules/soundswallower": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/soundswallower/-/soundswallower-0.5.0.tgz",
-            "integrity": "sha512-raqnqzgH7ivnHxsSIJyQbXyJT1xCxCw866HO9wxGAd4b/qgFvzv2SMo3cQBhdiBZM6dUyFirdSTZq6MqbKpwvg==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/soundswallower/-/soundswallower-0.6.0.tgz",
+            "integrity": "sha512-EC02+NKyyW/6M/u89PMvDxcS0SDMjkQwjrwEa9o38WYonTPLdoLE9hjye41EmFGyK/mBx3lGT0VTFeZlr64aAQ==",
             "dependencies": {
                 "@types/emscripten": "^1.39.6"
             }
@@ -22563,9 +22564,9 @@
             }
         },
         "soundswallower": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/soundswallower/-/soundswallower-0.5.0.tgz",
-            "integrity": "sha512-raqnqzgH7ivnHxsSIJyQbXyJT1xCxCw866HO9wxGAd4b/qgFvzv2SMo3cQBhdiBZM6dUyFirdSTZq6MqbKpwvg==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/soundswallower/-/soundswallower-0.6.0.tgz",
+            "integrity": "sha512-EC02+NKyyW/6M/u89PMvDxcS0SDMjkQwjrwEa9o38WYonTPLdoLE9hjye41EmFGyK/mBx3lGT0VTFeZlr64aAQ==",
             "requires": {
                 "@types/emscripten": "^1.39.6"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "bootstrap": "^5.2.3",
                 "ngx-toastr": "^15.0.0",
                 "rxjs": "~7.5.0",
-                "soundswallower": "^0.6.0",
+                "soundswallower": "^0.6.1",
                 "standardized-audio-context": "^25.3.36",
                 "tslib": "^2.3.0",
                 "zone.js": "~0.11.4"
@@ -12161,9 +12161,9 @@
             }
         },
         "node_modules/soundswallower": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/soundswallower/-/soundswallower-0.6.0.tgz",
-            "integrity": "sha512-EC02+NKyyW/6M/u89PMvDxcS0SDMjkQwjrwEa9o38WYonTPLdoLE9hjye41EmFGyK/mBx3lGT0VTFeZlr64aAQ==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/soundswallower/-/soundswallower-0.6.1.tgz",
+            "integrity": "sha512-kj5t+9SxNuSUfmIuhVL9xK8Sp1eweJT8qgSyz+iJ3TT6mO9szhDudOEzNBpncv3MCGn+kbT3zHXMKRm3O8XOEg==",
             "dependencies": {
                 "@types/emscripten": "^1.39.6"
             }
@@ -22564,9 +22564,9 @@
             }
         },
         "soundswallower": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/soundswallower/-/soundswallower-0.6.0.tgz",
-            "integrity": "sha512-EC02+NKyyW/6M/u89PMvDxcS0SDMjkQwjrwEa9o38WYonTPLdoLE9hjye41EmFGyK/mBx3lGT0VTFeZlr64aAQ==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/soundswallower/-/soundswallower-0.6.1.tgz",
+            "integrity": "sha512-kj5t+9SxNuSUfmIuhVL9xK8Sp1eweJT8qgSyz+iJ3TT6mO9szhDudOEzNBpncv3MCGn+kbT3zHXMKRm3O8XOEg==",
             "requires": {
                 "@types/emscripten": "^1.39.6"
             }

--- a/package.json
+++ b/package.json
@@ -34,11 +34,12 @@
         "@angular/platform-browser": "^15.1.1",
         "@angular/platform-browser-dynamic": "^15.1.1",
         "@angular/router": "^15.1.1",
+        "@types/emscripten": "^1.39.6",
         "angular-shepherd": "^14.0.0",
         "bootstrap": "^5.2.3",
         "ngx-toastr": "^15.0.0",
         "rxjs": "~7.5.0",
-        "soundswallower": "^0.5.0",
+        "soundswallower": "^0.6.0",
         "standardized-audio-context": "^25.3.36",
         "tslib": "^2.3.0",
         "zone.js": "~0.11.4"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "bootstrap": "^5.2.3",
         "ngx-toastr": "^15.0.0",
         "rxjs": "~7.5.0",
-        "soundswallower": "^0.6.0",
+        "soundswallower": "^0.6.1",
         "standardized-audio-context": "^25.3.36",
         "tslib": "^2.3.0",
         "zone.js": "~0.11.4"


### PR DESCRIPTION
Allows us to reduce, but sadly not eliminate, custom webpack configuration, because webpack's default behaviour is fine but Angular overrides it internally with something that doesn't work at all: https://github.com/angular/angular-cli/issues/24617